### PR TITLE
Generate and install systemd service unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,11 @@ install: strip
 	$(INSTALL) -D -m 0755 -s $(NAME) $(DESTDIR)$(PREFIX)/sbin/$(NAME)
 	$(INSTALL) -D -m 0644 $(NAME).1 $(DESTDIR)$(PREFIX)/share/man/man1/$(NAME).1
 	gzip -9 $(DESTDIR)$(PREFIX)/share/man/man1/$(NAME).1
+	sed "s|@PATH@|$(PREFIX)/sbin|" jitterentropy.service.in > jitterentropy.service
 
 clean:
 	@- $(RM) $(NAME)
 	@- $(RM) $(OBJS)
+	@- $(RM) jitterentropy.service
 
 distclean: clean

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ LDFLAGS ?=-Wl,-z,relro,-z,now
 DESTDIR :=
 INSTALL ?= install
 PREFIX := /usr/local
+UNITDIR := $(shell pkg-config --variable=systemdsystemunitdir systemd 2>/dev/null || echo /usr/lib/systemd/system)
 
 NAME := jitterentropy-rngd
 #C_SRCS := $(wildcard *.c)
@@ -40,6 +41,7 @@ install: strip
 	$(INSTALL) -D -m 0644 $(NAME).1 $(DESTDIR)$(PREFIX)/share/man/man1/$(NAME).1
 	gzip -9 $(DESTDIR)$(PREFIX)/share/man/man1/$(NAME).1
 	sed "s|@PATH@|$(PREFIX)/sbin|" jitterentropy.service.in > jitterentropy.service
+	$(INSTALL) -D -m 0644 jitterentropy.service $(DESTDIR)$(UNITDIR)/jitterentropy.service
 
 clean:
 	@- $(RM) $(NAME)

--- a/jitterentropy.service.in
+++ b/jitterentropy.service.in
@@ -13,7 +13,7 @@ After=local-fs.target
 Before=sysinit.target
 
 [Service]
-ExecStart=/usr/local/sbin/jitterentropy-rngd
+ExecStart=@PATH@/jitterentropy-rngd
 #PrivateTmp=yes
 #PrivateDevices=yes
 #ReadOnlyDirectories=/


### PR DESCRIPTION
The path might be overridden by the user with make install, so generate it at build time. Also install the unit in the appropriate directory.