### PR TITLE
Makefile: support cross compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Compile Noise Source as user space application
 
-CC=$(CROSS_COMPILE)gcc
-STRIP=$(CROSS_COMPILE)strip
+CC ?= $(CROSS_COMPILE)gcc
+STRIP ?= $(CROSS_COMPILE)strip
 CFLAGS ?=-Wextra -Wall -pedantic -fPIE -pie -fstack-protector-strong -fwrapv --param ssp-buffer-size=4
 LDFLAGS ?=-Wl,-z,relro,-z,now
 
@@ -9,7 +9,7 @@ LDFLAGS ?=-Wl,-z,relro,-z,now
 DESTDIR :=
 INSTALL ?= install
 PREFIX := /usr/local
-UNITDIR := $(shell pkg-config --variable=systemdsystemunitdir systemd 2>/dev/null || echo /usr/lib/systemd/system)
+UNITDIR ?= $(shell pkg-config --variable=systemdsystemunitdir systemd 2>/dev/null || echo /usr/lib/systemd/system)
 
 NAME := jitterentropy-rngd
 #C_SRCS := $(wildcard *.c)
@@ -37,7 +37,7 @@ strip: $(NAME)
 	$(STRIP) --strip-unneeded $(NAME)
 
 install: strip
-	$(INSTALL) -D -m 0755 -s $(NAME) $(DESTDIR)$(PREFIX)/sbin/$(NAME)
+	$(INSTALL) -D -m 0755 $(NAME) $(DESTDIR)$(PREFIX)/sbin/$(NAME)
 	$(INSTALL) -D -m 0644 $(NAME).1 $(DESTDIR)$(PREFIX)/share/man/man1/$(NAME).1
 	gzip -9 $(DESTDIR)$(PREFIX)/share/man/man1/$(NAME).1
 	sed "s|@PATH@|$(PREFIX)/sbin|" jitterentropy.service.in > jitterentropy.service


### PR DESCRIPTION
Change several assignments to allow use of environment variables
for cross compiling.  Also remove the -s (strip) option from the
install command since cross compiled binaries are not compatible.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>