### PR TITLE
jitterentropy-base: make it compile under clang

### DIFF
--- a/jitterentropy-base.c
+++ b/jitterentropy-base.c
@@ -50,7 +50,10 @@
  */
 
 #undef _FORTIFY_SOURCE
+
+#ifndef __clang__
 #pragma GCC optimize ("O0")
+#endif
 
 #include "jitterentropy.h"
 


### PR DESCRIPTION
Fixes following warning/error on clang-9:

```make
 jitterentropy-base.c:53:13: error: unknown pragma ignored [-Werror,-Wunknown-pragmas]
 #pragma GCC optimize ("O0")
```

Ref: https://gitlab.com/ynezz/openwrt-urngd/-/jobs/306413363
Signed-off-by: Petr Štetiar <ynezz@true.cz>