### PR TITLE
jitterentropy-rngd.1: spelling

### DIFF
--- a/jitterentropy-rngd.1
+++ b/jitterentropy-rngd.1
@@ -39,7 +39,7 @@ The CPU Jitter Random Number Generator works equally well in
 virtualized environments as well as on bare-metal provided
 a high-resolution timer is made available with the
 .BR clock_gettime ()
-function. The currently use timer can be checked by reading
+function. The currently used timer can be checked by reading
 the file
 .IR /sys/devices/system/clocksource/clocksource0/current_clocksource .
 If the clock source shall be changed, one of the available


### PR DESCRIPTION
Signed-off-by: Toralf Förster <toralf.foerster@gmx.de>