### PR TITLE
Strip BOM in jitterentropy.h

### DIFF
--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Non-physical true random number generator based on timing jitter.
  *
  * Copyright Stephan Mueller <smueller@chronox.de>, 2014 - 2021


### PR DESCRIPTION
It confuses old compilers.