### PR TITLE
Make using docker easier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM alpine
 
 RUN apk add --no-cache gcc libc-dev linux-headers make
 
-COPY *.c *.h Makefile /source/
+WORKDIR /source
+COPY *.c *.h Makefile ./
 
-RUN cd /source && make
+RUN make
 
 FROM alpine
 
 COPY --from=0 /source/jitterentropy-rngd /usr/bin
 
-CMD ["jitterentropy-rngd", "-v"]
+ENTRYPOINT ["/usr/bin/jitterentropy-rngd"]
+CMD ["-v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine
 RUN apk add --no-cache gcc libc-dev linux-headers make
 
 WORKDIR /source
+COPY lib/ lib/
 COPY *.c *.h Makefile ./
 
 RUN make

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Manual steps:
 
 1. Build an image from the latest source code.
 ```sh
-docker build -t smuellerDD/jitterentropy-rngd \
+docker build -t smuellerdd/jitterentropy-rngd \
     'https://github.com/smuellerDD/jitterentropy-rngd.git'
 ```
 
@@ -56,7 +56,7 @@ docker build -t smuellerDD/jitterentropy-rngd \
 ```sh
 docker run -d --name=rngd --restart=always \
     --cap-add=SYS_ADMIN --cap-drop=ALL \
-    --network=none smuellerDD/jitterentropy-rngd
+    --network=none smuellerdd/jitterentropy-rngd
 ```
 
 Version Numbers

--- a/README.md
+++ b/README.md
@@ -38,18 +38,25 @@ any cryptographic daemons, like sshd or a web server, benefits from a seeded
 Docker
 ======
 
-Run using docker-compose:
+Run using `docker compose`:
 
-```
-docker-compose up -d
+```sh
+docker compose up -d
 ```
 
-Build and run manually:
+Manual steps:
 
+1. Build an image from the latest source code.
+```sh
+docker build -t smuellerDD/jitterentropy-rngd \
+    'https://github.com/smuellerDD/jitterentropy-rngd.git'
 ```
-docker build -t jitterentropy-rngd .
-docker run --cap-add=SYS_ADMIN --cap-drop=ALL --name=rngd --network=none \
-    --restart=always -d jitterentropy-rngd
+
+2. Create and run a container using the newly built image.
+```sh
+docker run -d --name=rngd --restart=always \
+    --cap-add=SYS_ADMIN --cap-drop=ALL \
+    --network=none smuellerDD/jitterentropy-rngd
 ```
 
 Version Numbers

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,9 @@
-version: '2'
+name: jitterentropy
 
 services:
     rngd:
         build:
-            context: .
+            context: https://github.com/smuellerDD/jitterentropy-rngd.git
         cap_add:
             - SYS_ADMIN
         cap_drop:


### PR DESCRIPTION
- Update the `docker` files and instructions for the current status.

- Remove the requirement of checking out the source manually.

- Fix the missing `lib` directory causing the build to fail.