### PR TITLE
fix import of jitterentropy 3.7.0

### DIFF
--- a/jitterentropy-base-user.h
+++ b/jitterentropy-base-user.h
@@ -77,6 +77,10 @@
 #include <openssl/crypto.h>
 #endif
 
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#include <sys/mman.h>
+#endif
+
 #ifdef __MACH__
 #include <assert.h>
 #include <CoreServices/CoreServices.h>
@@ -127,23 +131,23 @@ static inline void jent_get_nstime(uint64_t *out)
 
 static inline void jent_get_nstime(uint64_t *out)
 {
-        uint64_t ctr_val;
+	uint64_t ctr_val;
 #if !defined(__MACH__)
-        /*
-         * Use the system counter for aarch64 (64 bit ARM)...
-         */
-        __asm__ __volatile__("mrs %0, " AARCH64_NSTIME_REGISTER : "=r" (ctr_val));
+	/*
+	 * Use the system counter for aarch64 (64 bit ARM)...
+	 */
+	__asm__ __volatile__("mrs %0, " AARCH64_NSTIME_REGISTER : "=r" (ctr_val));
 #else
-        /*
-         * Except on modern Apple platforms. Especially on M1 generation Arm64
-         * CPUs, the system counter is too coarse. Instead, use
-         * clock_gettime_nsec_np(CLOCK_UPTIME_RAW), that is equivalent to
-         * march_absolute_time(), but scaled to nanoseconds. See e.g.
-         * https://www.manpagez.com/man/3/clock_gettime_nsec_np/.
-         */
-        ctr_val = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+	/*
+	 * Except on modern Apple platforms. Especially on M1 generation Arm64
+	 * CPUs, the system counter is too coarse. Instead, use
+	 * clock_gettime_nsec_np(CLOCK_UPTIME_RAW), that is equivalent to
+	 * march_absolute_time(), but scaled to nanoseconds. See e.g.
+	 * https://www.manpagez.com/man/3/clock_gettime_nsec_np/.
+	 */
+	ctr_val = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 #endif
-        *out = ctr_val;
+	*out = ctr_val;
 }
 
 #elif defined(__s390x__)
@@ -211,12 +215,12 @@ static inline void jent_get_nstime(uint64_t *out)
 	unsigned long newhigh;
 	uint64_t result;
 #ifdef POWER_PC_USE_NEW_INSTRUCTIONS /* Newer PPC CPUs do not support mftbu/mftb */
-    __asm__ __volatile__(
-        "Lcpucycles:mfspr %0, 269;mfspr %1, 268;mfspr %2, 269;cmpw %0,%2;bne Lcpucycles"
+	__asm__ __volatile__(
+		"Lcpucycles:mfspr %0, 269;mfspr %1, 268;mfspr %2, 269;cmpw %0,%2;bne Lcpucycles"
 		: "=r" (high), "=r" (low), "=r" (newhigh)
 		);
 #else
-    __asm__ __volatile__(
+	__asm__ __volatile__(
 		"Lcpucycles:mftbu %0;mftb %1;mftbu %2;cmpw %0,%2;bne Lcpucycles"
 		: "=r" (high), "=r" (low), "=r" (newhigh)
 		);
@@ -231,18 +235,23 @@ static inline void jent_get_nstime(uint64_t *out)
 
 static inline void jent_get_nstime(uint64_t *out)
 {
-	/* OSX does not have clock_gettime -- taken from
-	 * http://developer.apple.com/library/mac/qa/qa1398/_index.html */
+	/*
+	 * OSX does not have clock_gettime -- taken from
+	 * http://developer.apple.com/library/mac/qa/qa1398/_index.html
+	 */
 # ifdef __MACH__
 	*out = mach_absolute_time();
 # elif _AIX
-	/* clock_gettime() on AIX returns a timer value that increments in
+	/*
+	 * clock_gettime() on AIX returns a timer value that increments in
 	 * steps of 1000
 	 */
 	uint64_t tmp = 0;
 	timebasestruct_t aixtime;
-	tmp = aixtime.tb_high * 1000000000UL;
-	tmp += aixtime.tb_low;
+	read_real_time(&aixtime, TIMEBASE_SZ);
+	time_base_to_time(&aixtime, TIMEBASE_SZ);
+	tmp = (uint64_t)aixtime.tb_high * 1000000000UL;
+	tmp += (uint64_t)aixtime.tb_low;
 	*out = tmp;
 # else /* __MACH__ */
 	/* we could use CLOCK_MONOTONIC(_RAW), but with CLOCK_REALTIME
@@ -251,8 +260,7 @@ static inline void jent_get_nstime(uint64_t *out)
 	 * extra little entropy */
 	uint64_t tmp = 0;
 	struct timespec time;
-	if (clock_gettime(CLOCK_REALTIME, &time) == 0)
-	{
+	if (clock_gettime(CLOCK_REALTIME, &time) == 0) {
 		tmp = ((uint64_t)time.tv_sec & 0xFFFFFFFF) * 1000000000UL;
 		tmp = tmp + (uint64_t)time.tv_nsec;
 	}
@@ -262,12 +270,23 @@ static inline void jent_get_nstime(uint64_t *out)
 
 #endif /* (__x86_64__) || (__i386__) || (__aarch64__) */
 
+static inline void jent_memset_secure(void *s, size_t n)
+{
+#if (defined(AWSLC) || defined(OPENSSL))
+	OPENSSL_cleanse(s, n);
+#else
+	memset(s, 0, n);
+	__asm__ __volatile__("" : : "r" (s) : "memory");
+#endif
+}
+
 static inline void *jent_zalloc(size_t len)
 {
 	#define JENT_BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
 	#define JENT_IS_POWER_OF_2(n) (JENT_BUILD_BUG_ON((n & (n - 1)) != 0))
 
 	void *tmp = NULL;
+
 #ifdef LIBGCRYPT
 	/* Set the maximum usable locked memory to 2 MiB at fist call.
 	 *
@@ -310,43 +329,72 @@ static inline void *jent_zalloc(size_t len)
 		OPENSSL_secure_free(tmp);
 		tmp = NULL;
 	}
+
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+	tmp = malloc(len);
+	if (!tmp)
+		return NULL;
+	/*
+	 * prevent paging out of the memory state to swap space
+	 * if this fails, check the current memory lock limits
+	 * and capabilities (e.g. RLIMIT_MEMLOCK and CAP_IPC_LOCK)
+	 */
+#ifndef JENT_CONF_RELAX_MLOCK
+#define CONFIG_CRYPTO_CPU_JITTERENTROPY_SECURE_MEMORY
+	if (mlock(tmp, len)) {
 #else
+	/*
+	 * use this only for CI or restricted containers if not possible
+	 * otherwise
+	 */
+	if (mlock(tmp, len) && errno != EPERM && errno != EAGAIN) {
+#endif
+		free(tmp);
+		return NULL;
+	}
+
+#else /* LIBGCRYPT */
+
 	/* we have no secure memory allocation! Hence
 	 * we do not set CONFIG_CRYPTO_CPU_JITTERENTROPY_SECURE_MEMORY */
 	tmp = malloc(len);
+
 #endif /* LIBGCRYPT */
+
 	if(NULL != tmp)
-		memset(tmp, 0, len);
+		jent_memset_secure(tmp, len);
 	return tmp;
 
 #undef JENT_IS_POWER_OF_2
 #undef JENT_BUILD_BUG_ON
 }
 
-static inline void jent_memset_secure(void *s, size_t n)
-{
-#if defined(AWSLC)
-	OPENSSL_cleanse(s, n);
-#else
-	memset(s, 0, n);
-	__asm__ __volatile__("" : : "r" (s) : "memory");
-#endif
-}
-
-static inline void jent_zfree(void *ptr, unsigned int len)
+static inline void jent_zfree(void *ptr, size_t len)
 {
 #ifdef LIBGCRYPT
 	/* gcry_free automatically wipes memory allocated with
 	 * gcry_(x)malloc_secure */
 	(void) len;
 	gcry_free(ptr);
+
 #elif defined(AWSLC)
 	/* AWS-LC stores the length of allocated memory internally and automatically wipes it in OPENSSL_free */
 	(void) len;
 	OPENSSL_free(ptr);
+
 #elif defined(OPENSSL)
 	OPENSSL_cleanse(ptr, len);
 	OPENSSL_secure_free(ptr);
+
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+	/* while memory returned to the OS is automatically unlocked,
+	 * it is not known how long libc keeps this memory cached
+	 * internally therefore its more robust to nevertheless
+	 * unlock here. */
+	munlock(ptr, len);
+	jent_memset_secure(ptr, len);
+	free(ptr);
+
 #else
 	jent_memset_secure(ptr, len);
 	free(ptr);
@@ -365,10 +413,15 @@ static inline int jent_fips_enabled(void)
 #define FIPS_MODE_SWITCH_FILE "/proc/sys/crypto/fips_enabled"
 	char buf[2] = "0";
 	int fd = 0;
+	ssize_t rlen;
 
 	if ((fd = open(FIPS_MODE_SWITCH_FILE, O_RDONLY)) >= 0) {
-		while (read(fd, buf, sizeof(buf)) < 0 && errno == EINTR);
+		do {
+			rlen = read(fd, buf, sizeof(buf));
+		} while (rlen < 0 && errno == EINTR);
 		close(fd);
+		if (rlen <= 0)
+			return 0;
 	}
 	if (buf[0] == '1')
 		return 1;
@@ -424,11 +477,12 @@ static inline void jent_get_cachesize_sysfs(long *l1, long *l2, long *l3)
 	unsigned int i;
 	char buf[10], file[50];
 	int fd = 0;
+	ssize_t rlen;
 
 	/* Iterate over all caches */
 	for (i = 0; i < 4; i++) {
 		unsigned int shift = 0;
-		char *ext;
+		char *ext, *endptr;
 
 		/*
 		 * Check the cache type - we are only interested in Unified
@@ -440,8 +494,12 @@ static inline void jent_get_cachesize_sysfs(long *l1, long *l2, long *l3)
 		fd = open(file, O_RDONLY);
 		if (fd < 0)
 			continue;
-		while (read(fd, buf, sizeof(buf)) < 0 && errno == EINTR);
+		do {
+			rlen = read(fd, buf, sizeof(buf));
+		} while (rlen < 0 && errno == EINTR);
 		close(fd);
+		if (rlen <= 0)
+			continue;
 		buf[sizeof(buf) - 1] = '\0';
 
 		if (strncmp(buf, "Data", 4) && strncmp(buf, "Unified", 7))
@@ -455,8 +513,12 @@ static inline void jent_get_cachesize_sysfs(long *l1, long *l2, long *l3)
 		fd = open(file, O_RDONLY);
 		if (fd < 0)
 			continue;
-		while (read(fd, buf, sizeof(buf)) < 0 && errno == EINTR);
+		do {
+			rlen = read(fd, buf, sizeof(buf));
+		} while (rlen < 0 && errno == EINTR);
 		close(fd);
+		if (rlen <= 0)
+			continue;
 		buf[sizeof(buf) - 1] = '\0';
 
 		ext = strstr(buf, "K");
@@ -471,8 +533,9 @@ static inline void jent_get_cachesize_sysfs(long *l1, long *l2, long *l3)
 			}
 		}
 
-		val = strtol(buf, NULL, 10);
-		if (val == LONG_MAX)
+		errno = 0;
+		val = strtol(buf, &endptr, 10);
+		if (errno != 0 || endptr == buf || val <= 0 || val == LONG_MAX)
 			continue;
 		val <<= shift;
 
@@ -543,34 +606,29 @@ static inline uint32_t jent_cache_size_to_memory(long l1, long l2, long l3,
 
 static inline uint32_t jent_cache_size_roundup(int all_caches)
 {
-	static int checked = 0;
 	uint32_t cache_size = 0;
-	int checked_all_caches = all_caches + 1;
 
-	if (!cache_size || checked != checked_all_caches) {
-		long l1 = 0, l2 = 0, l3 = 0;
+	long l1 = 0, l2 = 0, l3 = 0;
 
-		jent_get_cachesize_sysconf(&l1, &l2, &l3);
-		checked = checked_all_caches;
+	jent_get_cachesize_sysconf(&l1, &l2, &l3);
 
-		cache_size = jent_cache_size_to_memory(l1, l2, l3, all_caches);
-		#ifdef __linux__
-		if (cache_size == 0) {
-			jent_get_cachesize_sysfs(&l1, &l2, &l3);
-			cache_size = jent_cache_size_to_memory(l1, l2, l3,
-							       all_caches);
+	cache_size = jent_cache_size_to_memory(l1, l2, l3, all_caches);
+	#ifdef __linux__
+	if (cache_size == 0) {
+		jent_get_cachesize_sysfs(&l1, &l2, &l3);
+		cache_size = jent_cache_size_to_memory(l1, l2, l3,
+							all_caches);
 
-			if (cache_size == 0)
-				return 0;
-		}
-		#endif
-
-		/*
-		 * Make the output_size the smallest power of 2 strictly
-		 * greater than cache_size.
-		 */
-		cache_size++;
+		if (cache_size == 0)
+			return 0;
 	}
+	#endif
+
+	/*
+	 * Make the output_size the smallest power of 2 strictly
+	 * greater than cache_size.
+	 */
+	cache_size++;
 
 	return cache_size;
 }

--- a/jitterentropy.h
+++ b/jitterentropy.h
@@ -98,8 +98,8 @@ extern "C" {
 
 /* Flags field limiting the amount of memory to be used for memory access */
 #define JENT_FLAGS_TO_MEMSIZE_SHIFT	27
-#define JENT_FLAGS_TO_MAX_MEMSIZE(val)	(val >> JENT_FLAGS_TO_MEMSIZE_SHIFT)
-#define JENT_MAX_MEMSIZE_TO_FLAGS(val)	(val << JENT_FLAGS_TO_MEMSIZE_SHIFT)
+#define JENT_FLAGS_TO_MAX_MEMSIZE(val)	((val) >> JENT_FLAGS_TO_MEMSIZE_SHIFT)
+#define JENT_MAX_MEMSIZE_TO_FLAGS(val)	((val) << JENT_FLAGS_TO_MEMSIZE_SHIFT)
 #define JENT_MAX_MEMSIZE_1kB		JENT_MAX_MEMSIZE_TO_FLAGS(UINT32_C( 1))
 #define JENT_MAX_MEMSIZE_2kB		JENT_MAX_MEMSIZE_TO_FLAGS(UINT32_C( 2))
 #define JENT_MAX_MEMSIZE_4kB		JENT_MAX_MEMSIZE_TO_FLAGS(UINT32_C( 3))
@@ -130,10 +130,10 @@ extern "C" {
 
 /* Flags field defining the hash loop */
 #define JENT_FLAGS_TO_HASHLOOP_SHIFT	24
-#define JENT_HASHLOOP_TO_FLAGS(val)	(val << JENT_FLAGS_TO_HASHLOOP_SHIFT)
+#define JENT_HASHLOOP_TO_FLAGS(val)	((val) << JENT_FLAGS_TO_HASHLOOP_SHIFT)
 #define JENT_MAX_HASHLOOP_MASK		JENT_HASHLOOP_TO_FLAGS(0x7)
-#define JENT_FLAGS_TO_HASHLOOP(val)	((val >> JENT_FLAGS_TO_HASHLOOP_SHIFT) &\
-					 0x7)
+#define JENT_FLAGS_TO_HASHLOOP(val)	(((val) >> JENT_FLAGS_TO_HASHLOOP_SHIFT)\
+					 & 0x7)
 #define JENT_HASHLOOP_1			JENT_HASHLOOP_TO_FLAGS(UINT32_C(0))
 #define JENT_HASHLOOP_2			JENT_HASHLOOP_TO_FLAGS(UINT32_C(1))
 #define JENT_HASHLOOP_4			JENT_HASHLOOP_TO_FLAGS(UINT32_C(2))
@@ -154,7 +154,7 @@ extern "C" {
 #endif
 #endif
 
-#if defined(__MINGW32__) || defined(__APPLE__)
+#if defined(__MINGW32__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #define JENT_PTHREAD
 #endif
 
@@ -289,7 +289,7 @@ void jent_notime_fini(void *ctx);
 #define JENT_LAG_FAILURE	4 /* Failure in Lag predictor health test. */
 #define JENT_RCT_MEM_FAILURE	8 /* Failure in RCT with memory health test. */
 #define JENT_PERMANENT_FAILURE_SHIFT	16
-#define JENT_PERMANENT_FAILURE(x)	(x << JENT_PERMANENT_FAILURE_SHIFT)
+#define JENT_PERMANENT_FAILURE(x)	((x) << JENT_PERMANENT_FAILURE_SHIFT)
 #define JENT_RCT_FAILURE_PERMANENT	JENT_PERMANENT_FAILURE(JENT_RCT_FAILURE)
 #define JENT_APT_FAILURE_PERMANENT	JENT_PERMANENT_FAILURE(JENT_APT_FAILURE)
 #define JENT_LAG_FAILURE_PERMANENT	JENT_PERMANENT_FAILURE(JENT_LAG_FAILURE)


### PR DESCRIPTION
Hi Stephan,

I noticed, that something got missing, as secure memory support was always false in the status output.

BR
Markus