### PR TITLE
systemd: allow locking secure memory

### DIFF
--- a/jitterentropy.service.in
+++ b/jitterentropy.service.in
@@ -19,7 +19,7 @@ DeviceAllow=/dev/random rw
 DevicePolicy=strict
 ExecStart=@PATH@/jitterentropy-rngd
 IPAddressDeny=any
-LimitMEMLOCK=512
+LimitMEMLOCK=2M
 LockPersonality=yes
 MemoryDenyWriteExecute=yes
 MountFlags=private
@@ -41,7 +41,7 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 SystemCallArchitectures=native
 SystemCallFilter=@system-service
-SystemCallFilter=~@chown @clock @cpu-emulation @debug @ipc @module @mount @obsolete @privileged @raw-io @reboot @resources @swap memfd_create mincore mlock mlockall personality
+SystemCallFilter=~@chown @clock @cpu-emulation @debug @ipc @module @mount @obsolete @privileged @raw-io @reboot @resources @swap memfd_create mincore mlock personality
 UMask=0077
 
 [Install]


### PR DESCRIPTION
Fixes https://github.com/smuellerDD/jitterentropy-rngd/issues/33

As reported in #33, changing `LimitMEMLOCK` is not enough on its own: `jitterentropy-rngd` now uses `mlock()`, but the systemd unit still blocks that syscall with `SystemCallFilter`, so the daemon gets killed by seccomp.

After allowing `mlock`, I also hit initialization failures when `LimitMEMLOCK` was too low. `1M` worked in my testing, but this bumps it to `2M` to match `JENT_SECURE_MEMORY_SIZE_MAX` and give the daemon enough room for its secure memory allocations